### PR TITLE
Select restrictions

### DIFF
--- a/Org.OData.Capabilities.V1.xml
+++ b/Org.OData.Capabilities.V1.xml
@@ -316,6 +316,18 @@ Overview:
         <Member Name="group" Value="16" />
       </EnumType>
 
+      <Term Name="SelectRestrictions" Type="Capabilities.SelectRestrictionsType" AppliesTo="EntitySet">
+        <Annotation Term="Core.Description" String="Restrictions on $select expressions" />
+      </Term>
+      <ComplexType Name="SelectRestrictionsType">
+        <Property Name="Selectable" Type="Edm.Boolean" DefaultValue="true">
+          <Annotation Term="Core.Description" String="$select is supported" />
+        </Property>
+        <Property Name="NonSelectableProperties" Type="Collection(Edm.NavigationPropertyPath)">
+          <Annotation Term="Core.Description" String="These properties cannot be used in $select expressions" />
+        </Property>
+      </ComplexType>
+
       <!-- Data Modification Capabilities -->
 
       <Term Name="InsertRestrictions" Type="Capabilities.InsertRestrictionsType" AppliesTo="EntitySet">

--- a/Org.OData.Capabilities.V1.xml
+++ b/Org.OData.Capabilities.V1.xml
@@ -323,7 +323,7 @@ Overview:
         <Property Name="Selectable" Type="Edm.Boolean" DefaultValue="true">
           <Annotation Term="Core.Description" String="$select is supported" />
         </Property>
-        <Property Name="NonSelectableProperties" Type="Collection(Edm.NavigationPropertyPath)">
+        <Property Name="NonSelectableProperties" Type="Collection(Edm.PropertyPath)">
           <Annotation Term="Core.Description" String="These properties cannot be used in $select expressions" />
         </Property>
       </ComplexType>


### PR DESCRIPTION
Similar to how the Capabilities vocabulary allows annotating entity sets with information about when an entity set supports $filter, $orderby, and $expand, it should be possible to express the ability to use $select, and which properties may be explicitly not selectable.

An example of why this is needed:
Some services may have the same entity exposed in different entity sets, with different sets of properties available from the different entity sets. This may happen more often with non-contained entities. For example, a service with both Products and Orders entity sets, where Product can have a collection of Orders it is part of, and Order can have a collection of Products it includes, it may be possible to select all Product properties from /Products, but a limited selection of propertiess from /Orders(id)/Products.
